### PR TITLE
feat: automated DSA question bank + dynamic PYQ integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# ETL data (large generated files — seed via scripts/seed-dsa.mjs instead)
+/data/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.89.0",
+        "cheerio": "^1.2.0",
+        "csv-parse": "^6.2.1",
         "next": "^16.1.0",
         "nodemailer": "^6.9.7",
         "react": "19.2.3",
@@ -68,7 +70,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1632,7 +1633,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1696,7 +1696,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -2166,7 +2165,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2444,6 +2442,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2485,7 +2489,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2591,6 +2594,48 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2640,11 +2685,45 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2781,6 +2860,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2807,6 +2941,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
@@ -2818,6 +2965,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3015,7 +3174,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3193,7 +3351,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3826,12 +3983,55 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -4915,6 +5115,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5106,6 +5318,55 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5237,7 +5498,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5246,7 +5506,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5424,6 +5683,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5892,7 +6157,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6044,7 +6308,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6092,6 +6355,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6170,6 +6442,28 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6324,7 +6618,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.89.0",
+    "cheerio": "^1.2.0",
+    "csv-parse": "^6.2.1",
     "next": "^16.1.0",
     "nodemailer": "^6.9.7",
     "react": "19.2.3",

--- a/scripts/build-dsa-db.mjs
+++ b/scripts/build-dsa-db.mjs
@@ -1,0 +1,230 @@
+/**
+ * scripts/build-dsa-db.mjs
+ *
+ * ETL Pipeline: Builds a curated JSON bank of company-tagged DSA questions.
+ *
+ * Steps:
+ *  1. Parses All.csv files from `data/interview-company-wise-problems/`
+ *     (cloned from github.com/liquidslr/interview-company-wise-problems)
+ *  2. Fetches full problem descriptions via LeetCode's GraphQL API.
+ *  3. Falls back to scraping leetcode.ca (via sitemap reverse-lookup) for
+ *     premium/locked questions not accessible via the public API.
+ *  4. Writes deduplicated output to `data/dsa_db_final.json`.
+ *
+ * Usage:
+ *   node scripts/build-dsa-db.mjs
+ *
+ * Then seed Into Supabase:
+ *   node --env-file=.env.local scripts/seed-dsa.mjs data/dsa_db_final.json
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { parse } from "csv-parse/sync";
+import * as cheerio from "cheerio";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "node:crypto";
+
+const LEETCODE_API = "https://leetcode.com/graphql";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || "http://127.0.0.1:54321"; // fallback for types, needs real env
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "dummy";
+
+// Maximum number of unique questions to process in this run
+const MAX_QUESTIONS_TO_PROCESS = Infinity; 
+const CONCURRENCY_LIMIT = 5;
+
+// GraphQL Query
+const QUESTION_DATA_QUERY = `
+  query questionData($titleSlug: String!) {
+    question(titleSlug: $titleSlug) {
+      questionId questionFrontendId title titleSlug isPaidOnly difficulty likes dislikes categoryTitle
+      topicTags { name slug }
+      content hints
+    }
+  }
+`;
+
+// Helper: delays to prevent rate limits
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+async function fetchGraphQL(slug) {
+  try {
+    const res = await fetch(LEETCODE_API, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: QUESTION_DATA_QUERY, variables: { titleSlug: slug } }),
+    });
+    if (!res.ok) return null;
+    const { data } = await res.json();
+    return data?.question;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function getSitemapMap() {
+  console.log("Downloading leetcode.ca sitemap...");
+  const res = await fetch("https://leetcode.ca/sitemap.xml");
+  const xml = await res.text();
+  const regex = /<loc>(https:\/\/leetcode\.ca\/([^<]+))<\/loc>/g;
+  let match;
+  const map = {};
+  while ((match = regex.exec(xml)) !== null) {
+      const url = match[1];
+      // Format is roughly https://leetcode.ca/YYYY-MM-DD-{id}-Title/
+      const parts = url.split('-');
+      // ID is typically the 4th segment or after the date
+      // We can just rely on regex looking for -id- when querying
+  }
+  return xml; // returnsraw because regex on demand is safer
+}
+
+async function scrapePremiumFallback(id, sitemapXml) {
+  const searchPattern = `-${id}-`;
+  const regex = /<loc>(https:\/\/leetcode\.ca\/([^<]+))<\/loc>/g;
+  let match;
+  let targetUrl = `https://leetcode.ca/all/${id}.html`; // default old
+  
+  while ((match = regex.exec(sitemapXml)) !== null) {
+      if (match[1].includes(searchPattern)) {
+          targetUrl = match[1];
+          break;
+      }
+  }
+
+  try {
+    const res = await fetch(targetUrl);
+    if (!res.ok) return null;
+    const html = await res.text();
+    const $ = cheerio.load(html);
+    let content = $("article.post-content").html() || $(".markdown-body").html() || $("article.blog-post").html();
+    if (content) {
+      const solIdx = content.toLowerCase().indexOf('<h2 id="solution"');
+      if (solIdx !== -1) content = content.substring(0, solIdx);
+      return { content: content.trim(), url: targetUrl };
+    }
+  } catch (e) {}
+  return null;
+}
+
+async function main() {
+  const sitemapXml = await getSitemapMap();
+  const repoPath = path.resolve("data/interview-company-wise-problems");
+  if (!fs.existsSync(repoPath)) {
+    console.error("Please run: git clone https://github.com/liquidslr/interview-company-wise-problems.git data/interview-company-wise-problems");
+    process.exit(1);
+  }
+
+  // 1. Traverse all companies and aggregate into a Slug Map
+  console.log("Parsing CSVs to build Company map...");
+  const slugMap = new Map();
+  const companies = fs.readdirSync(repoPath, { withFileTypes: true })
+                      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+                      .map(d => d.name);
+
+  // Process ALL companies in the repository
+  for (const company of companies) {
+    
+    // Read the master "All.csv" or "5. All.csv" to get all questions for the company without duplicate parsing
+    const filesToRead = ["5. All.csv", "All.csv"];
+    for (const file of filesToRead) {
+      const csvPath = path.join(repoPath, company, file);
+      if (!fs.existsSync(csvPath)) continue;
+
+      const content = fs.readFileSync(csvPath, "utf-8");
+      const records = parse(content, { columns: true, skip_empty_lines: true });
+
+      for (const row of records) {
+        if (!row.Link) continue;
+        const slugMatch = row.Link.match(/problems\/([^/]+)/);
+        if (!slugMatch) continue;
+        
+        const slug = slugMatch[1];
+        if (!slugMap.has(slug)) {
+          slugMap.set(slug, {
+            slug,
+            title: row.Title,
+            difficulty: row.Difficulty,
+            topics: row.Topics ? row.Topics.split(',').map(t => t.trim()) : [],
+            companies: new Set()
+          });
+        }
+        slugMap.get(slug).companies.add(company);
+      }
+    }
+  }
+
+  let slugsToProcess = Array.from(slugMap.values());
+  console.log(`Found ${slugsToProcess.length} unique questions across target companies.`);
+  
+  if (slugsToProcess.length > MAX_QUESTIONS_TO_PROCESS) {
+      slugsToProcess = slugsToProcess.slice(0, MAX_QUESTIONS_TO_PROCESS);
+      console.log(`Limiting to ${MAX_QUESTIONS_TO_PROCESS} questions for this batch...`);
+  }
+
+  const finalDatabaseRows = [];
+  
+  // 2. Process concurrently with limit
+  console.log("Fetching descriptions from Leetcode GraphQL (with leetcode.ca fallback)...");
+  
+  for (let i = 0; i < slugsToProcess.length; i += CONCURRENCY_LIMIT) {
+    const chunk = slugsToProcess.slice(i, i + CONCURRENCY_LIMIT);
+    
+    await Promise.all(chunk.map(async (meta) => {
+      const q = await fetchGraphQL(meta.slug);
+      let promptHtml = q?.content;
+      let usedFallback = false;
+      let isPremium = q?.isPaidOnly || false;
+      let sourceUrl = `https://leetcode.com/problems/${meta.slug}/`;
+
+      if (!q) return; // Skip if graphql failed completely
+
+      if (isPremium || !promptHtml) {
+        const fb = await scrapePremiumFallback(q.questionFrontendId, sitemapXml);
+        if (fb) {
+           promptHtml = fb.content;
+           usedFallback = true;
+           sourceUrl = fb.url;
+        }
+      }
+
+      if (!promptHtml) {
+         console.log(`[SKIP] Could not fetch prompt for ${meta.slug}`);
+         return;
+      }
+
+      finalDatabaseRows.push({
+        slug: meta.slug,
+        source: usedFallback ? "leetcode.ca" : "leetcode",
+        source_id: q.questionFrontendId,
+        source_url: sourceUrl,
+        title: q.title,
+        difficulty: q.difficulty,
+        topics: meta.topics.length ? meta.topics : q.topicTags.map(t => t.name),
+        companies: Array.from(meta.companies),
+        prompt: promptHtml,
+        constraints: null,
+        examples: [],
+        hints: q.hints || [],
+        metadata: {
+          isPaidOnly: isPremium,
+          category: q.categoryTitle,
+          likes: q.likes,
+          dislikes: q.dislikes,
+          used_fallback_scraper: usedFallback
+        }
+      });
+    }));
+
+    process.stdout.write(`\rProcessed ${Math.min(i + CONCURRENCY_LIMIT, slugsToProcess.length)}/${slugsToProcess.length}`);
+    await sleep(500); // 500ms delay between chunks to avoid rate limiting
+  }
+
+  console.log("\nSaving to data/dsa_db_final.json");
+  fs.writeFileSync(path.resolve("data/dsa_db_final.json"), JSON.stringify(finalDatabaseRows, null, 2));
+
+  // Note: To automatically insert, run `npm run seed:dsa data/dsa_db_final.json`
+  console.log(`\nSuccessfully compiled ${finalDatabaseRows.length} questions ready for Supabase seeding!`);
+}
+
+main().catch(console.error);

--- a/scripts/fetch-leetcode.mjs
+++ b/scripts/fetch-leetcode.mjs
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import * as cheerio from "cheerio";
+
+const LEETCODE_API_ENDPOINT = "https://leetcode.com/graphql";
+
+const QUESTION_DATA_QUERY = `
+  query questionData($titleSlug: String!) {
+    question(titleSlug: $titleSlug) {
+      questionId
+      questionFrontendId
+      title
+      titleSlug
+      isPaidOnly
+      difficulty
+      likes
+      dislikes
+      categoryTitle
+      topicTags {
+        name
+        slug
+      }
+      content
+      hints
+    }
+  }
+`;
+
+async function fetchLeetCodeQuestion(slug) {
+  console.log(`Fetching data for slug: "${slug}"...`);
+  try {
+    const response = await fetch(LEETCODE_API_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: QUESTION_DATA_QUERY, variables: { titleSlug: slug } }),
+    });
+
+    if (!response.ok) throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+    const { data, errors } = await response.json();
+    if (errors) {
+      console.error("GraphQL Errors:", errors);
+      return null;
+    }
+    return data.question;
+  } catch (error) {
+    console.error("Fetch failed:", error);
+    return null;
+  }
+}
+
+async function scrapeLeetcodeCa(id) {
+  try {
+    const url = `https://leetcode.ca/all/${id}.html`;
+    console.log(`Fallback triggered -> Scraping ${url}`);
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const html = await res.text();
+    const $ = cheerio.load(html);
+    
+    let content = $("article.post-content").html() || $(".markdown-body").html();
+    
+    if (content) {
+      // leetcode.ca often includes solutions at the bottom. We can strip anything after <h2 id="solution"> or <h2>Solution
+      const solutionIndex = content.toLowerCase().indexOf('<h2 id="solution"');
+      if (solutionIndex !== -1) {
+        content = content.substring(0, solutionIndex);
+      }
+      return content.trim();
+    }
+  } catch (e) {
+    console.error("Scrape failed", e);
+  }
+  return null;
+}
+
+async function main() {
+  const slug = process.argv[2] || "two-sum";
+  const questionData = await fetchLeetCodeQuestion(slug);
+  
+  if (!questionData) {
+     console.log("No data found for slug.");
+     return;
+  }
+
+  let promptHtml = questionData.content;
+  let usedFallback = false;
+
+  // Premium lock check
+  if (questionData.isPaidOnly || !promptHtml) {
+    console.log("Question is Premium/Locked. Attempting leetcode.ca fallback...");
+    promptHtml = await scrapeLeetcodeCa(questionData.questionFrontendId);
+    usedFallback = true;
+  }
+
+  const formattedForDB = {
+    slug: questionData.titleSlug,
+    source: usedFallback ? "leetcode.ca" : "leetcode",
+    source_id: questionData.questionFrontendId,
+    source_url: `https://leetcode.com/problems/${questionData.titleSlug}/`,
+    title: questionData.title,
+    difficulty: questionData.difficulty,
+    topics: questionData.topicTags.map(tag => tag.name),
+    companies: [], 
+    prompt: promptHtml,
+    constraints: null, 
+    examples: [], 
+    hints: questionData.hints || [],
+    metadata: {
+      isPaidOnly: questionData.isPaidOnly,
+      category: questionData.categoryTitle,
+      likes: questionData.likes,
+      dislikes: questionData.dislikes,
+      used_fallback_scraper: usedFallback
+    }
+  };
+
+  console.log("\n--- FORMATTED DATA FOR DATABASE ---");
+  const output = { ...formattedForDB, prompt: formattedForDB.prompt ? formattedForDB.prompt.substring(0, 150) + "... [TRUNCATED]" : null };
+  console.log(JSON.stringify(output, null, 2));
+
+  fs.writeFileSync(`${slug}-test.json`, JSON.stringify(formattedForDB, null, 2));
+  console.log(`\nFull output saved to ${slug}-test.json`);
+}
+
+main();

--- a/scripts/seed-dsa.mjs
+++ b/scripts/seed-dsa.mjs
@@ -29,10 +29,10 @@ function normalizeJson(value, fallback) {
 }
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl) die("Missing env var NEXT_PUBLIC_SUPABASE_URL");
-if (!supabaseAnonKey) die("Missing env var NEXT_PUBLIC_SUPABASE_ANON_KEY");
+if (!supabaseKey) die("Missing env var SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY");
 
 const fileArg = process.argv[2];
 if (!fileArg) {
@@ -55,7 +55,7 @@ try {
 const rows = Array.isArray(raw) ? raw : Array.isArray(raw?.data) ? raw.data : null;
 if (!rows) die("JSON must be an array of question objects, or { data: [...] }");
 
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const supabase = createClient(supabaseUrl, supabaseKey);
 
 const mapped = rows.map((r) => {
   const title = r.title ?? r.name ?? r.question ?? r.problem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -577,3 +577,44 @@ body { font-family: 'Inter', sans-serif; background-color: var(--bg-deep); color
   }
 }
 
+/* LeetCode Custom Question Content Formatting */
+.leetcode-html-content {
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+.leetcode-html-content p {
+  margin-bottom: 1rem;
+}
+.leetcode-html-content code {
+  background-color: rgba(30, 41, 59, 0.8);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85em;
+  color: #93c5fd;
+}
+.leetcode-html-content pre {
+  background-color: rgba(15, 23, 42, 0.8);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  margin: 1rem 0;
+}
+.leetcode-html-content pre code {
+  background-color: transparent;
+  padding: 0;
+  color: #e2e8f0;
+}
+.leetcode-html-content ul, .leetcode-html-content ol {
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+.leetcode-html-content li {
+  margin-bottom: 0.5rem;
+}
+.leetcode-html-content strong, .leetcode-html-content b {
+  color: #ffffff;
+  font-weight: 600;
+}
+

--- a/src/components/EditorWorkspace.tsx
+++ b/src/components/EditorWorkspace.tsx
@@ -118,8 +118,8 @@ export default function EditorWorkspace({ company, topic, duration, excludeTopic
     setUnlocked(false);
     setMessages([]);
     setInterviewState("intro");
-    setCurrentQuestion(FIXED_THREE_SUM_QUESTION);
-    setTestCases(getDefaultThreeSumTestCases());
+    setCurrentQuestion(null);
+    setTestCases([]);
     setCurrentTestIndex(0);
     setTestResults([]);
     setSubmissionStatus(null);
@@ -232,6 +232,32 @@ export default function EditorWorkspace({ company, topic, duration, excludeTopic
 
         if (error) throw error;
         if (!cancelled) sessionIdRef.current = (data as any)?.id ?? stableId;
+
+        // Fetch custom PYQ in background
+        const { data: qData, error: qErr } = await supabase.rpc('pick_random_dsa_question', {
+          p_company: company === 'Generic' ? null : company,
+          p_exclude_topics: excludeTopics && excludeTopics.length > 0 ? excludeTopics : null,
+          p_session_id: stableId
+        });
+
+        if (!cancelled) {
+          if (!qErr && qData) {
+            setCurrentQuestion(qData);
+            setTestCases((qData.examples && Array.isArray(qData.examples)) ? qData.examples.map((ex: any) => ({
+              input: String(ex.input ?? ""),
+              expected: String(ex.output ?? ex.expected ?? ""),
+              custom: false
+            })) : []);
+            
+            // Setup the initial IDE editor value with a nice comment
+            const header = `// -----------------------------------------------------\n// Company: ${company !== 'Generic' ? company : 'Any'}\n// Topic: ${topic}\n// Problem: ${qData.title}\n// -----------------------------------------------------\n\n`;
+            setEditorValue(`${header}class Solution {\npublic:\n    // Implement your solution here\n    \n};\n`);
+          } else {
+            setCurrentQuestion(FIXED_THREE_SUM_QUESTION);
+            setTestCases(getDefaultThreeSumTestCases());
+            console.warn("Falling back to fixed question, fetch failed:", qErr);
+          }
+        }
       } catch (e) {
         console.warn("Failed to create interview session row", e);
       }
@@ -335,6 +361,7 @@ export default function EditorWorkspace({ company, topic, duration, excludeTopic
     setAgentText("Analyzing approach... Logic seems sound. Unlocking editor.");
     setListening(false);
     setTimeout(() => {
+      setInterviewState('coding');
       setUnlocked(true);
       setAgentText(`Editor unlocked. You have ${duration} minutes to implement the solution.`);
       editorRef.current?.focus();
@@ -590,9 +617,12 @@ export default function EditorWorkspace({ company, topic, duration, excludeTopic
           </div>
 
           <div className="flex-1 overflow-y-auto p-6 scroll-smooth">
-            <div className="mb-4">
-              <span className="text-xs font-bold text-green-400 bg-green-400/10 px-2 py-1 rounded">{currentQuestion?.difficulty || "Loading..."}</span>
-              <span className="text-xs font-bold text-slate-400 ml-2">{topic}</span>
+            <div className="mb-4 flex items-center gap-2">
+              <span className={`text-xs font-bold px-2 py-1 rounded ${currentQuestion?.difficulty === 'Hard' ? 'text-red-400 bg-red-400/10' : currentQuestion?.difficulty === 'Medium' ? 'text-yellow-400 bg-yellow-400/10' : 'text-green-400 bg-green-400/10'}`}>{currentQuestion?.difficulty || "Loading..."}</span>
+              {company && company !== "Generic" && (
+                <span className="text-xs font-bold text-blue-400 bg-blue-400/10 px-2 py-1 rounded">{company}</span>
+              )}
+              <span className="text-xs font-bold text-slate-400 ml-1">{topic}</span>
             </div>
             {(excludeTopics ?? []).length > 0 && (
               <div className="mb-4">
@@ -607,11 +637,17 @@ export default function EditorWorkspace({ company, topic, duration, excludeTopic
               </div>
             )}
 
-            {currentQuestion ? (
+            {interviewState === 'intro' ? (
+              <div className="flex flex-col items-center justify-center h-64 text-slate-500 animate-pulse bg-slate-800/20 rounded-xl border border-white/5 p-8 mt-12">
+                <svg className="w-12 h-12 mb-4 text-blue-500/50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" /></svg>
+                <p className="text-sm font-semibold text-slate-300">Preparing Custom Interview Scenario...</p>
+                <p className="text-xs mt-2 text-slate-500 text-center max-w-xs">Question will be presented automatically when the introduction phase completes.</p>
+              </div>
+            ) : currentQuestion ? (
               <>
                 <h2 className="text-xl font-bold mb-4">{currentQuestion.title}</h2>
                 <div className="prose prose-invert prose-sm text-slate-300">
-                  <p>{currentQuestion.description || currentQuestion.prompt}</p>
+                  <div className="leetcode-html-content" dangerouslySetInnerHTML={{ __html: currentQuestion.prompt || currentQuestion.description }} />
 
                   {currentQuestion.examples && Array.isArray(currentQuestion.examples) && currentQuestion.examples.map((ex: any, i: number) => (
                     <div key={i} className="bg-slate-800/50 p-4 rounded-lg border border-white/5 my-4">


### PR DESCRIPTION
#8 

- Add ETL pipeline (scripts/build-dsa-db.mjs) that:
  * Parses company-wise CSVs from liquidslr/interview-company-wise-problems
  * Fetches problem descriptions via LeetCode GraphQL API
  * Falls back to scraping leetcode.ca for premium/locked questions
  * Outputs to data/dsa_db_final.json (gitignored, 1820 questions)

- Add seeder (scripts/seed-dsa.mjs) that bulk-upserts into Supabase dsa_questions table, using service role key to bypass RLS

- Update EditorWorkspace.tsx to:
  * Background-fetch a company-specific PYQ during intro phase
  * Call pick_random_dsa_question RPC with company + excludeTopics
  * Reveal question seamlessly when state transitions to coding
  * Render LeetCode HTML prompt via dangerouslySetInnerHTML
  * Pre-init editor with company/topic/problem header comment

- Add .leetcode-html-content CSS rules in globals.css for proper rendering of code blocks, lists, and strong tags

- Add /data/ to .gitignore (large generated JSON + cloned repo)
- Remove debug/test scripts (test-cheerio, test-sitemap, debug_rpc)